### PR TITLE
1.1.0 added user specific profiles

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     }
 }
 
-version "1.1.0-SNAPSHOT"
+version "1.1.0"
 group "au.org.ala"
 
 apply plugin:"eclipse"

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -161,7 +161,7 @@ headerAndFooter:
 
 security:
     cas:
-        uriFilterPattern: '/dataprofiles,/filters/*,/download.*'
+        uriFilterPattern: '/data-profiles,/filters/*,/download.*'
         authenticateOnlyIfLoggedInPattern: '/occurrences/(?!.+userAssertions|facet.+).+,/explore/your-area,/query,/proxy/download/.*'
         uriExclusionFilterPattern: '/occurrences/shapeUpload,/images.*,/css.*,/js.*,.*json,/help/.*'
 
@@ -175,15 +175,20 @@ environments:
             serverURL: "http://dev.ala.org.au:8090/data-quality"
         security:
             cas:
-                appServerName: "https://auth.ala.org.au"
+                appServerName: "http://dev.ala.org.au"
+                casServerName: "https://auth-test.ala.org.au"
+                casServerUrlPrefix: ${security.cas.casServerName}/cas
+                loginUrl: ${security.cas.casServerUrlPrefix}/login
+                logoutUrl: ${security.cas.casServerUrlPrefix}/logout
+                contextPath: "/data-quality"
     test:
         security:
             cas:
-                appServerName: "https://auth.ala.org.au"
+                appServerName: "http://dev.ala.org.au"
     production:
         security:
             cas:
-                appServerName: "https://auth.ala.org.au"
+                appServerName: "http://dev.ala.org.au"
 
 biocache:
     indexedFieldsUrl: "${biocache.baseUrl}/index/fields"

--- a/grails-app/controllers/au/org/ala/dataqualityfilter/AddProfileInterceptor.groovy
+++ b/grails-app/controllers/au/org/ala/dataqualityfilter/AddProfileInterceptor.groovy
@@ -1,0 +1,38 @@
+package au.org.ala.dataqualityfilter
+
+class AddProfileInterceptor {
+    AddProfileInterceptor() {
+        match(controller: "adminDataQuality", action: "saveProfile")
+        match(controller: "adminDataQuality", action: "importProfile")
+    }
+
+    // 1 user can only have 1 private profile, checks are done here
+    boolean before() {
+        while (true) {
+
+            def requestUserId = null
+            def profileId = null
+
+            if (params.action in ['saveProfile']) {
+                requestUserId = params.userId ?: null
+                profileId = params.id ?: null
+            } else if (params.action in ['importProfile']) {
+                requestUserId = request.getParameter('userId') ?: null
+            }
+
+            // if public profile, no limit
+            if (requestUserId == null) return true
+
+            // must be private profile here
+            List<QualityCategory> existingProfiles = QualityProfile.findAllByUserId(requestUserId)
+            if (existingProfiles.size() > 1) {
+                break
+            } else if (existingProfiles.size() == 1 && profileId == null) { // profileId == null means create new profile
+                break
+            }
+            return true
+        }
+        flash.message = 'you can only have 1 private profile'
+        redirect(controller: "adminDataQuality", action: "data-profiles")
+    }
+}

--- a/grails-app/controllers/au/org/ala/dataqualityfilter/AdminDataQualityInterceptor.groovy
+++ b/grails-app/controllers/au/org/ala/dataqualityfilter/AdminDataQualityInterceptor.groovy
@@ -1,0 +1,52 @@
+package au.org.ala.dataqualityfilter
+
+class AdminDataQualityInterceptor {
+    AdminDataQualityInterceptor() {
+        match(controller: "adminDataQuality", action: "saveProfile")
+        match(controller: "adminDataQuality", action: "importProfile")
+        match(controller: "adminDataQuality", action: "enableQualityProfile")
+        match(controller: "adminDataQuality", action: "setDefaultProfile")
+        match(controller: "adminDataQuality", action: "exportProfile")
+        match(controller: "adminDataQuality", action: "deleteQualityProfile")
+    }
+
+    def userService
+
+    boolean before() {
+        // several things are checked here
+        // 1. user must be logged in
+        // 2. only admin can edit/export public profiles
+        // 3. non-admin user can only edit/export his own profile
+        while (true) {
+            def loggedInUserId = userService.getLoggedInUserId()
+
+            // if not logged in
+            if (!loggedInUserId) {
+                flash.message = 'you need to login to make changes to the profiles'
+                break;
+            }
+
+            def requestUserId = null
+
+            if (params.action in ['saveProfile', 'enableQualityProfile', 'setDefaultProfile', 'exportProfile', 'deleteQualityProfile']) {
+                requestUserId = params.userId ?: null
+            } else if (params.action == 'importProfile') {
+                requestUserId = request.getParameter('userId') ?: null
+            }
+
+            // if current logged in is not admin but save a public profile, fail it
+            if (!requestUserId && !userService.isLoggedInAdmin()) {
+                flash.message = 'you need to admin to edit/export public profiles'
+                break
+            }
+            // we can only save using the logged in id
+            if (requestUserId != null && requestUserId != loggedInUserId) {
+                flash.message = 'you can only edit/export your own profiles'
+                break
+            }
+            return true
+        }
+
+        redirect(controller: "adminDataQuality", action: "data-profiles")
+    }
+}

--- a/grails-app/controllers/au/org/ala/dataqualityfilter/QualityController.groovy
+++ b/grails-app/controllers/au/org/ala/dataqualityfilter/QualityController.groovy
@@ -29,10 +29,11 @@ class QualityController {
             @ApiResponse(code = SC_OK, message = "OK", response = String, responseContainer = "Map")
     ])
     @ApiImplicitParams([
-            @ApiImplicitParam(name = "profileName", paramType = "query", required = false, value = "Profile name", dataType = 'string')
+            @ApiImplicitParam(name = "profileName", paramType = "query", required = false, value = "Profile name", dataType = 'string'),
+            @ApiImplicitParam(name = "userId", paramType = "query", required = false, value = "the userId used to get the default profile in case profile name is not provided", dataType = 'string')
     ])
-    def getEnabledFiltersByLabel(String profileName) {
-        render qualityService.getEnabledFiltersByLabel(profileName) as JSON
+    def getEnabledFiltersByLabel(String profileName, String userId) {
+        render qualityService.getEnabledFiltersByLabel(profileName, userId) as JSON
     }
     final class GetEnabledFiltersByLabelResponse extends LinkedHashMap<String, String> {}
 
@@ -46,10 +47,11 @@ class QualityController {
             @ApiResponse(code = SC_OK, message = "OK", response = String, responseContainer = "List")
     ])
     @ApiImplicitParams([
-            @ApiImplicitParam(name = "profileName", paramType = "query", required = false, value = "Profile name", dataType = 'string')
+            @ApiImplicitParam(name = "profileName", paramType = "query", required = false, value = "Profile name", dataType = 'string'),
+            @ApiImplicitParam(name = "userId", paramType = "query", required = false, value = "the userId used to get the default profile in case profile name is not provided", dataType = 'string')
     ])
-    def getEnabledQualityFilters(String profileName) {
-        render qualityService.getEnabledQualityFilters(profileName) as JSON
+    def getEnabledQualityFilters(String profileName, String userId) {
+        render qualityService.getEnabledQualityFilters(profileName, userId) as JSON
     }
 
     /** This class is unused other than to provides the type information for the OpenAPI definition */
@@ -65,10 +67,11 @@ class QualityController {
             @ApiResponse(code = SC_OK, message = "OK", response = GetGroupedEnabledFiltersResponse) // , responseContainer = "Map"
     ])
     @ApiImplicitParams([
-            @ApiImplicitParam(name = "profileName", paramType = "query", required = false, value = "Profile name", dataType = 'string')
+            @ApiImplicitParam(name = "profileName", paramType = "query", required = false, value = "Profile name", dataType = 'string'),
+            @ApiImplicitParam(name = "userId", paramType = "query", required = false, value = "the userId used to get the default profile in case profile name is not provided", dataType = 'string')
     ])
-    def getGroupedEnabledFilters(String profileName) {
-        render qualityService.getGroupedEnabledFilters(profileName) as JSON
+    def getGroupedEnabledFilters(String profileName, String userId) {
+        render qualityService.getGroupedEnabledFilters(profileName, userId) as JSON
     }
 
     @ApiOperation(
@@ -81,10 +84,11 @@ class QualityController {
             @ApiResponse(code = SC_OK, message = "OK", response = QualityCategory, responseContainer = "List")
     ])
     @ApiImplicitParams([
-            @ApiImplicitParam(name = "profileName", paramType = "query", required = false, value = "Profile name", dataType = 'string')
+            @ApiImplicitParam(name = "profileName", paramType = "query", required = false, value = "Profile name", dataType = 'string'),
+            @ApiImplicitParam(name = "userId", paramType = "query", required = false, value = "the userId used to get the default profile in case profile name is not provided", dataType = 'string')
     ])
-    def findAllEnabledCategories(String profileName) {
-        render qualityService.findAllEnabledCategories(profileName) as JSON
+    def findAllEnabledCategories(String profileName, String userId) {
+        render qualityService.findAllEnabledCategories(profileName, userId) as JSON
     }
 
     @ApiOperation(
@@ -97,10 +101,11 @@ class QualityController {
             @ApiResponse(code = SC_OK, message = "OK", response = QualityProfile)
     ])
     @ApiImplicitParams([
-            @ApiImplicitParam(name = "profileName", paramType = "query", required = false, value = "The profile short name", dataType = 'string')
+            @ApiImplicitParam(name = "profileName", paramType = "query", required = false, value = "The profile short name", dataType = 'string'),
+            @ApiImplicitParam(name = "userId", paramType = "query", required = false, value = "the userId used to get active profile in case profile name is not provided", dataType = 'string')
     ])
-    def activeProfile(String profileName) {
-        render qualityService.activeProfile(profileName) as JSON
+    def activeProfile(String profileName, String userId) {
+        render qualityService.activeProfile(profileName, userId) as JSON
     }
 
     @ApiOperation(
@@ -113,10 +118,11 @@ class QualityController {
             @ApiResponse(code = SC_OK, message = "OK", response = String)
     ])
     @ApiImplicitParams([
-            @ApiImplicitParam(name = "profileName", paramType = "query", required = false, value = "Profile name", dataType = 'string')
+            @ApiImplicitParam(name = "profileName", paramType = "query", required = false, value = "Profile name", dataType = 'string'),
+            @ApiImplicitParam(name = "userId", paramType = "query", required = false, value = "the userId used to get the default profile in case profile name is not provided", dataType = 'string')
     ])
-    def getJoinedQualityFilter(String profileName) {
-        render qualityService.getJoinedQualityFilter(profileName), contentType: 'text/plain'
+    def getJoinedQualityFilter(String profileName, String userId) {
+        render qualityService.getJoinedQualityFilter(profileName, userId), contentType: 'text/plain'
     }
 
     @ApiOperation(
@@ -156,5 +162,4 @@ class QualityController {
         def result = qualityService.getAllInverseCategoryFilters(params.long('qualityProfileId'))
         render result as JSON
     }
-
 }

--- a/grails-app/controllers/au/org/ala/dataqualityfilter/QualityProfileController.groovy
+++ b/grails-app/controllers/au/org/ala/dataqualityfilter/QualityProfileController.groovy
@@ -47,7 +47,8 @@ class QualityProfileController extends RestfulController<QualityProfile> {
             @ApiImplicitParam(name = "order", paramType = "query", required = false, value = "Direction to sort results by", dataType = 'string'),
             @ApiImplicitParam(name = "enabled", paramType = "query", required = false, value = "Only return enabled profiles", dataType = 'boolean'),
             @ApiImplicitParam(name = "name", paramType = "query", required = false, value = "Search for profiles by name", dataType = 'string'),
-            @ApiImplicitParam(name = "shortName", paramType = "query", required = false, value = "Search for profiles by short name", dataType = 'string')
+            @ApiImplicitParam(name = "shortName", paramType = "query", required = false, value = "Search for profiles by short name", dataType = 'string'),
+            @ApiImplicitParam(name = "userId", paramType = "query", required = false, value = "the userId used to search private profiles", dataType = 'string')
     ])
     def index(Integer max) {
         super.index(max)

--- a/grails-app/domain/au/org/ala/dataqualityfilter/QualityProfile.groovy
+++ b/grails-app/domain/au/org/ala/dataqualityfilter/QualityProfile.groovy
@@ -16,6 +16,10 @@ class QualityProfile {
     String contactName
     String contactEmail
 
+    // to which user this profile belongs
+    // if null means it's a public profile available to everyone
+    String userId
+    boolean isPublic
     boolean enabled
     boolean isDefault
 
@@ -30,6 +34,7 @@ class QualityProfile {
         name unique: true, blank: false, nullable: false
         shortName unique: true, blank: false, nullable: false
         contactEmail blank: true, nullable: true
+        userId blank: false, nullable: true
 
         // TODO remove after db updated
         contactName blank: true, nullable: true
@@ -43,6 +48,7 @@ class QualityProfile {
         description type: 'text'
         contactName type: 'text'
         contactEmail type: 'text'
+        isPublic formula: 'user_id is null'
         enabled defaultValue: 'true', index: 'quality_profile_enabled_idx'
         categories sort: 'displayOrder'
         sort 'displayOrder'

--- a/grails-app/services/au/org/ala/dataqualityfilter/UserService.groovy
+++ b/grails-app/services/au/org/ala/dataqualityfilter/UserService.groovy
@@ -1,0 +1,21 @@
+package au.org.ala.dataqualityfilter
+
+import grails.gorm.transactions.Transactional
+import au.org.ala.web.CASRoles
+
+@Transactional
+class UserService {
+    def authService
+
+    def getLoggedInUserId() {
+        authService?.getUserId()
+    }
+
+    def isLoggedInAdmin() {
+        isAdmin(getLoggedInUserId())
+    }
+
+    private def isAdmin(String userId) {
+        authService?.getUserForUserId(userId)?.hasRole(CASRoles.ROLE_ADMIN)
+    }
+}

--- a/grails-app/views/adminDataQuality/_profilesTableTemplate.gsp
+++ b/grails-app/views/adminDataQuality/_profilesTableTemplate.gsp
@@ -1,0 +1,66 @@
+<div class="row">
+    <div class="col-md-12" style="margin-bottom: 5px">
+        <h1>${label}</h1>
+        <g:set var="disableCreate" value="${type == 'private' && profiles != null && profiles.size() == 1}"/>
+
+        <g:if test="${disableCreate}">
+            <a class="addProfileLink btn btn-primary" role="button" data-toggle="modal" data-target="#save-profile-modal" data-type="${type}" data-userId="${userId}" disabled><alatag:message code="add.profile.button" default="Add Profile" /></a>
+            <a class="importProfileLink btn btn-primary" role="button" data-toggle="modal" data-target="#import-profile-modal" data-type="${type}" data-userId="${userId}" disabled><alatag:message code="dq.admin.import.profile.button" default="Import a profile"/></a>
+        </g:if>
+        <g:else>
+            <a class="addProfileLink btn btn-primary" role="button" data-toggle="modal" data-target="#save-profile-modal" data-type="${type}" data-userId="${userId}"><alatag:message code="add.profile.button" default="Add Profile" /></a>
+            <a class="importProfileLink btn btn-primary" role="button" data-toggle="modal" data-target="#import-profile-modal" data-type="${type}" data-userId="${userId}"><alatag:message code="dq.admin.import.profile.button" default="Import a profile"/></a>
+        </g:else>
+
+    </div>
+    <div class="col-md-12">
+        <table id="profiletable" class="table table-bordered table-hover table-striped table-responsive">
+            <thead>
+            <tr>
+                <th>Id</th>
+                <th>Name</th>
+                <th>short-name</th>
+                <th>enabled</th>
+                <th></th>
+            </tr>
+            </thead>
+            <tbody>
+            <g:if test="${profiles != null && profiles.size() > 0}">
+                <g:each in="${profiles.sort{it.displayOrder}}" var="profile">
+                    <tr id="profile-${profile.id}" data-curdisplayorder="${profile.displayOrder}">
+                        <td style="vertical-align: middle; width:10%"><img src="${assetPath(src: 'menu.png')}" class="dragHandle" data-toggle="tooltip" title="drag/drop to re-order profiles"></img>&nbsp;&nbsp;${profile.id}</td>
+                        <td style="vertical-align: middle; width:35%"><g:link action="filters" id="${profile.id}">${profile.name}</g:link></td>
+                        <td style="vertical-align: middle; width:20%">${profile.shortName}</td>
+                        <td style="vertical-align: middle; width:5%">
+                            <g:form action="enableQualityProfile" useToken="true">
+                                <g:hiddenField name="id" value="${profile.id}" />
+                                <g:hiddenField name="userId" value="${profile.userId}" />
+                                <g:checkBox name="enabled" value="${profile.enabled}" disabled="${profile.isDefault}"  />
+                            </g:form>
+                        </td>
+                        <td style="width:30%">
+                            <button data-id="${profile.id}" data-name="${profile.name}" data-short-name="${profile.shortName}" data-description="${profile.description}" data-contact-name="${profile.contactName}" data-contact-email="${profile.contactEmail}" data-is-default="${profile.isDefault}" data-enabled="${profile.enabled}" data-type="${type}" data-userId="${userId}" class="btn btn-default btn-edit-profile"><i class="fa fa-edit"></i></button>
+                            <g:if test="${enableDefault}">
+                                <g:form action="setDefaultProfile" class="form-inline" style="display:inline;" useToken="true">
+                                    <g:hiddenField name="id" value="${profile.id}" />
+                                    <g:hiddenField name="userId" value="${profile.userId}" />
+                                    <button type="submit" class="btn btn-${profile.isDefault ? 'primary' : 'default'} ${profile.isDefault ? ' active' : ''}" aria-pressed="${profile.isDefault}">Default</button>
+                                </g:form>
+                            </g:if>
+                            <g:form action="deleteQualityProfile" data-confirmation="${profile.categories.size() > 0}" class="form-inline" style="display:inline;" useToken="true">
+                                <g:hiddenField name="id" value="${profile.id}" />
+                                <g:hiddenField name="userId" value="${profile.userId}" />
+                                <button type="submit" class="btn btn-danger" ${profile.isDefault ? 'disabled' : ''}><i class="fa fa-trash"></i></button>
+                            </g:form>
+                            <g:link action="exportProfile" id="${profile.id}" params="${[userId: profile.userId]}"><button class="btn btn-default"><alatag:message code="dq.admin.export.profile.button" default="Export profile"/></button></g:link>
+                            <g:form class="updateProfileDisplayOrder" useToken="true">
+                                <g:hiddenField name="id" value="${profile.id}"></g:hiddenField>
+                            </g:form>
+                        </td>
+                    </tr>
+                </g:each>
+            </g:if>
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/grails-app/views/adminDataQuality/data-profiles.gsp
+++ b/grails-app/views/adminDataQuality/data-profiles.gsp
@@ -41,116 +41,75 @@
             </ul>
         </div>
     </g:hasErrors>
-    <div class="row">
-        <div class="col-md-12" style="margin-bottom: 5px">
-            <h1>Data Quality Profiles</h1>
-            <button data-toggle="modal" data-target="#save-profile-modal" class="btn btn-primary"><alatag:message code="add.profile.button" default="Add Profile" /></button>
-            <button data-toggle="modal" data-target="#import-profile-modal" class="btn btn-primary"><alatag:message code="dq.admin.import.profile.button" default="Import a profile"/></button>
-        </div>
-        <div class="col-md-12">
-            <table id="profiletable" class="table table-bordered table-hover table-striped table-responsive">
-                <thead>
-                <tr>
-                    <th>Id</th>
-                    <th>Name</th>
-                    <th>short-name</th>
-                    <th>enabled</th>
-                    <th></th>
-                </tr>
-                </thead>
-                <tbody>
-                <g:if test="${qualityProfileInstanceList != null && qualityProfileInstanceList.size() > 0}">
-                    <g:each in="${qualityProfileInstanceList.sort{it.displayOrder}}" var="profile">
-                        <tr id="profile-${profile.id}" data-curdisplayorder="${profile.displayOrder}">
-                            <td style="vertical-align: middle"><img src="${assetPath(src: 'menu.png')}" class="dragHandle" data-toggle="tooltip" title="drag/drop to re-order profiles"></img>&nbsp;&nbsp;${profile.id}</td>
-                            <td style="vertical-align: middle"><g:link action="filters" id="${profile.id}">${profile.name}</g:link></td>
-                            <td style="vertical-align: middle">${profile.shortName}</td>
-                            <td style="vertical-align: middle">
-                                <g:form action="enableQualityProfile" useToken="true">
-                                    <g:hiddenField name="id" value="${profile.id}" />
-                                    <g:checkBox name="enabled" value="${profile.enabled}" disabled="${profile.isDefault}"  />
-                                </g:form>
-                            </td>
-                            <td>
-                                <button data-id="${profile.id}" data-name="${profile.name}" data-short-name="${profile.shortName}" data-description="${profile.description}" data-contact-name="${profile.contactName}" data-contact-email="${profile.contactEmail}" data-is-default="${profile.isDefault}" data-enabled="${profile.enabled}" class="btn btn-default btn-edit-profile"><i class="fa fa-edit"></i></button>
-                                <g:form action="setDefaultProfile" class="form-inline" style="display:inline;" useToken="true">
-                                    <g:hiddenField name="id" value="${profile.id}" />
-                                    <button type="submit" class="btn btn-${profile.isDefault ? 'primary' : 'default'} ${profile.isDefault ? ' active' : ''}" aria-pressed="${profile.isDefault}">Default</button>
-                                </g:form>
-                                <g:form action="deleteQualityProfile" data-confirmation="${profile.categories.size() > 0}" class="form-inline" style="display:inline;" useToken="true">
-                                    <g:hiddenField name="id" value="${profile.id}" />
-                                    <button type="submit" class="btn btn-danger" ${profile.isDefault ? 'disabled' : ''}><i class="fa fa-trash"></i></button>
-                                </g:form>
-                                <g:link action="exportProfile" id="${profile.id}"><button class="btn btn-default"><alatag:message code="dq.admin.export.profile.button" default="Export profile"/></button></g:link>
-                                <g:form class="updateProfileDisplayOrder" useToken="true">
-                                    <g:hiddenField name="id" value="${profile.id}"></g:hiddenField>
-                                </g:form>
-                            </td>
-                        </tr>
-                    </g:each>
-                </g:if>
-                </tbody>
-            </table>
-        </div>
-        <div id="save-profile-modal" class="modal fade" tabindex="-1" role="dialog">
-            <div class="modal-dialog" role="document">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                        <h4 class="modal-title"><alatag:message code="profile.modal.title" default="New Profile" /></h4>
-                    </div>
-                    <div class="modal-body">
-                        <g:form name="save-profile-form" action="saveProfile" useToken="true">
-                            <g:hiddenField name="id" value="" />
-                            <g:hiddenField name="enabled" value="false" />
-                            <g:hiddenField name="isDefault" value="false" />
-                            <div class="form-group">
-                                <label for="name"><alatag:message code="profile.modal.name.label" default="Name" /></label>
-                                <input type="text" class="form-control" id="name" name="name" placeholder="Name">
-                            </div>
-                            <div class="form-group">
-                                <label for="shortName"><alatag:message code="profile.modal.shortName.label" default="Short name" /></label>
-                                <input type="text" class="form-control" id="shortName" name="shortName" placeholder="short-name">
-                                <p class="help-block"><alatag:message code="profile.modal.shortName.help" default="Label used for selecting this profile in URLs and the like.  A single lower case word is preferred." /></p>
-                            </div>
-                            <div class="form-group">
-                                <label for="description"><alatag:message code="profile.modal.description.label" default="Description" /></label>
-                                <input type="text" class="form-control" id="description" name="description" placeholder="description...">
-                            </div>
-                            <div class="form-group">
-                                <label for="contactName"><alatag:message code="profile.modal.contactName.label" default="Contact Name" /></label>
-                                <input type="text" class="form-control" id="contactName" name="contactName" placeholder="Contact Name">
-                            </div>
-                            <div class="form-group">
-                                <label for="contactEmail"><alatag:message code="profile.modal.contactName.label" default="Contact Email (Optional)" /></label>
-                                <input type="email" class="form-control" id="contactEmail" name="contactEmail" placeholder="contact.email@example.org">
-                            </div>
-                        </g:form>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                        <button type="submit" form="save-profile-form" class="btn btn-primary">Save changes</button>
-                    </div>
-                </div><!-- /.modal-content -->
-            </div><!-- /.modal-dialog -->
-        </div><!-- /.modal -->
 
-        <div id="import-profile-modal" class="modal fade" tabindex="-1" role="dialog">
-            <div class="modal-dialog" role="document">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                        <h4 class="modal-title"><alatag:message code="dq.admin.uploadprofile.modal.title" default="Import a profile" /></h4>
-                    </div>
-                    <div class="modal-body">
-                        <g:form name="import-profile-form" action="importProfile" enctype="multipart/form-data" useToken="true">
-                            <input type="file" name="filejson"/>
-                        </g:form>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-                        <button type="submit" form="import-profile-form" class="btn btn-primary">Upload</button>
-                    </div>
+    <g:if test="${publicProfiles != null}">
+        <g:render template="profilesTableTemplate" model="[label:'Public Data Quality Profiles', type:'public', userId:userId, enableDefault:true, profiles:publicProfiles]"/>
+    </g:if>
+
+    <g:if test="${privateProfiles != null}">
+        <g:render template="profilesTableTemplate" model="[label:'Private Data Quality Profiles', type:'private', userId:userId, enableDefault:false, profiles:privateProfiles]"/>
+    </g:if>
+
+    <div id="save-profile-modal" class="modal fade" tabindex="-1" role="dialog">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <h4 class="modal-title"><alatag:message code="profile.modal.title" default="New Profile" /></h4>
+                </div>
+                <div class="modal-body">
+                    <g:form name="save-profile-form" action="saveProfile" useToken="true">
+                        <g:hiddenField name="id" value="" />
+                        <g:hiddenField name="enabled" value="false" />
+                        <g:hiddenField name="isDefault" value="false" />
+                        <g:hiddenField name="userId" value=""/>
+                        <div class="form-group">
+                            <label for="name"><alatag:message code="profile.modal.name.label" default="Name" /></label>
+                            <input type="text" class="form-control" id="name" name="name" placeholder="Name">
+                        </div>
+                        <div class="form-group">
+                            <label for="shortName"><alatag:message code="profile.modal.shortName.label" default="Short name" /></label>
+                            <input type="text" class="form-control" id="shortName" name="shortName" placeholder="short-name">
+                            <p class="help-block"><alatag:message code="profile.modal.shortName.help" default="Label used for selecting this profile in URLs and the like.  A single lower case word is preferred." /></p>
+                        </div>
+                        <div class="form-group">
+                            <label for="description"><alatag:message code="profile.modal.description.label" default="Description" /></label>
+                            <input type="text" class="form-control" id="description" name="description" placeholder="description...">
+                        </div>
+                        <div class="form-group">
+                            <label for="contactName"><alatag:message code="profile.modal.contactName.label" default="Contact Name" /></label>
+                            <input type="text" class="form-control" id="contactName" name="contactName" placeholder="Contact Name">
+                        </div>
+                        <div class="form-group">
+                            <label for="contactEmail"><alatag:message code="profile.modal.contactName.label" default="Contact Email (Optional)" /></label>
+                            <input type="email" class="form-control" id="contactEmail" name="contactEmail" placeholder="contact.email@example.org">
+                        </div>
+                    </g:form>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                    <button type="submit" form="save-profile-form" class="btn btn-primary">Save changes</button>
+                </div>
+            </div><!-- /.modal-content -->
+        </div><!-- /.modal-dialog -->
+    </div><!-- /.modal -->
+
+    <div id="import-profile-modal" class="modal fade" tabindex="-1" role="dialog">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <h4 class="modal-title"><alatag:message code="dq.admin.uploadprofile.modal.title" default="Import a profile" /></h4>
+                </div>
+                <div class="modal-body">
+                    <g:form name="import-profile-form" action="importProfile" enctype="multipart/form-data" useToken="true">
+                        <g:hiddenField name="userId" value=""/>
+                        <input type="file" name="filejson"/>
+                    </g:form>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                    <button type="submit" form="import-profile-form" class="btn btn-primary">Upload</button>
                 </div>
             </div>
         </div>
@@ -231,6 +190,25 @@
             }
         });
 
+        $('.addProfileLink, .importProfileLink').click(function() {
+            var type = $(this).attr('data-type');
+            var uid = $(this).attr('data-userId');
+
+            var uidControl = null;
+            var className = $(this).attr('class');
+            if (className.indexOf('addProfileLink') !== -1) {
+                uidControl = $('#save-profile-modal form').find('input[name=userId]');
+            } else if (className.indexOf('importProfileLink') !== -1) {
+                uidControl = $('#import-profile-modal form').find('input[name=userId]');
+            }
+
+            if (type === 'public') {
+                $(uidControl).val("");
+            } else if (type === 'private') {
+                $(uidControl).val(uid);
+            }
+        })
+
         $('.btn-edit-profile').on('click', function(e) {
             var $this = $(this);
             var id = $this.data('id');
@@ -241,6 +219,8 @@
             var contactEmail  = $this.data('contact-email');
             var enabled = $this.data('enabled');
             var isDefault = $this.data('is-default');
+            var userId = $this.attr('data-userId');
+            var type = $this.attr('data-type');
 
             var $saveProfileModal = $('#save-profile-modal');
 
@@ -252,6 +232,7 @@
             var $contactEmail = $saveProfileModal.find('input[name=contactEmail]');
             var $enabled = $saveProfileModal.find('input[name=enabled]');
             var $isDefault = $saveProfileModal.find('input[name=isDefault]');
+            var $uidControl = $saveProfileModal.find('input[name=userId]');
 
             var oldId = $id.val();
             var oldName = $name.val();
@@ -270,6 +251,11 @@
             $contactEmail.val(contactEmail);
             $enabled.val(enabled);
             $isDefault.val(isDefault);
+            if (type === 'public') {
+                $uidControl.val("");
+            } else if (type === 'private') {
+                $uidControl.val(userId);
+            }
 
             var clearFormFn = function() {
                 $id.val(oldId);


### PR DESCRIPTION
This changes includes user profile changes.

1. `QualityProfile` has a new field `userId`, if it's null means it's a public profile, if not null, it specifies the owner of the profile
2. Changes to frontend, so when add/edit/export/import correct userId is set (null or '' for admin, not-null for normal user). 
3. A few interceptors put in place to guarantee: 
    - only admin can add/edit/export public profile
    - if normal user, the profile being processed should have same userId as currently logged in user.